### PR TITLE
Prevent Firefox NS_ERROR_FAILURE:

### DIFF
--- a/src/js/core.js
+++ b/src/js/core.js
@@ -149,7 +149,8 @@
             return;
         }
 
-        if (MediumEditor.util.isMediumEditorElement(node) && node.children.length === 0) {
+        if (MediumEditor.util.isMediumEditorElement(node) && node.children.length === 0  &&
+            !MediumEditor.util.isBlockContainer(node)) {
             this.options.ownerDocument.execCommand('formatBlock', false, 'p');
         }
 


### PR DESCRIPTION
In Firefox if the editable is a node without children, then NS_ERROR_FAILURE: error thrown for every keyup until it gets a child node. 

Issue: https://github.com/yabwe/medium-editor/issues/994
